### PR TITLE
Add level loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,18 @@ This project is intended as a starting point for experimenting with OGRE Next
 and Bullet. It displays 1980s inspired on-screen instructions and fires small
 spheres as bullets using Bullet's physics simulation.
 
+## Levels
+Objects for the environment are described in a simple text format. A sample
+`level.txt` file is included and loaded on start up. Each line contains an
+object type followed by position and scale values:
+
+```
+wall 0 0 10 1 2 0.2
+obstacle 0 0 0 1 1 1
+```
+
+This allows experimenting with different maps by editing or providing a new
+level file.
+
 ## License
 Released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/level.txt
+++ b/level.txt
@@ -1,0 +1,6 @@
+# type x y z sx sy sz
+wall 0 0 10 1 2 0.2
+wall 0 0 -10 1 2 0.2
+wall 10 0 0 0.2 2 1
+wall -10 0 0 0.2 2 1
+obstacle 0 0 0 1 1 1

--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -10,6 +10,7 @@
 #include <OgreTrays.h>
 
 #include <btBulletDynamicsCommon.h>
+#include <string>
 
 class GameApp;
 
@@ -43,6 +44,8 @@ public:
     bool frameRenderingQueued(const Ogre::FrameEvent& evt) override;
 
 private:
+    void addStaticCube(const Ogre::Vector3& position, const Ogre::Vector3& scale);
+    void loadLevel(const std::string& filename);
     void createBullet(const Ogre::Vector3& position, const Ogre::Quaternion& orient);
 
     btDiscreteDynamicsWorld* mDynamicsWorld;
@@ -55,6 +58,7 @@ private:
     Ogre::SceneManager* mSceneMgr;
     OgreBites::TrayManager* mTrayMgr;
     Ogre::OverlaySystem* mOverlaySystem;
+    InputHandler* mInputHandler;
 };
 
 #endif // GAME_APP_HPP


### PR DESCRIPTION
## Summary
- implement simple text-based level loader
- create utility to spawn static cubes with Bullet collision
- load sample `level.txt` at startup
- document level format in README

## Testing
- `cmake ..` *(fails: could not find OGRE)*

------
https://chatgpt.com/codex/tasks/task_e_683fc1e31e208328837abbc44d6d3cd5