### PR TITLE
Add basic game state and HUD overlays

### DIFF
--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -31,6 +31,22 @@ private:
     bool mJump;
 };
 
+struct GameState
+{
+    int health;
+    int ammo;
+    int score;
+    bool paused;
+    bool gameOver;
+    bool won;
+
+    GameState()
+        : health(100), ammo(20), score(0), paused(false), gameOver(false),
+          won(false)
+    {
+    }
+};
+
 class GameApp : public OgreBites::ApplicationContext, public OgreBites::InputListener
 {
 public:
@@ -42,8 +58,14 @@ public:
     bool mousePressed(const OgreBites::MouseButtonEvent& evt) override;
     bool frameRenderingQueued(const Ogre::FrameEvent& evt) override;
 
+    void restartGame();
+
 private:
     void createBullet(const Ogre::Vector3& position, const Ogre::Quaternion& orient);
+
+    void togglePause();
+    void updateHUD();
+    void setGameOver(bool won);
 
     btDiscreteDynamicsWorld* mDynamicsWorld;
     btBroadphaseInterface* mBroadphase;
@@ -55,6 +77,13 @@ private:
     Ogre::SceneManager* mSceneMgr;
     OgreBites::TrayManager* mTrayMgr;
     Ogre::OverlaySystem* mOverlaySystem;
+
+    InputHandler* mInputHandler;
+    GameState mGameState;
+
+    OgreBites::Label* mCrosshair;
+    OgreBites::ProgressBar* mHealthBar;
+    OgreBites::Label* mScoreLabel;
 };
 
 #endif // GAME_APP_HPP


### PR DESCRIPTION
## Summary
- implement `GameState` struct for health, ammo, score and game status
- extend `GameApp` HUD with crosshair, health bar, and score display
- support pausing, restarting and simple win/lose conditions

## Testing
- `cmake ..` *(fails: Could not find OGRE)*

------
https://chatgpt.com/codex/tasks/task_e_683fc1e75244832887126bb7cf987a59