### PR TITLE
Implement basic gameplay helpers

### DIFF
--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -129,6 +129,13 @@ private:
     std::vector<BulletProjectile*> mBullets;
     std::vector<Enemy*> mEnemies;
 
+    GameState mGameState;
+    Weapon* mWeapon{nullptr};
+    OgreBites::Label* mCrosshair{nullptr};
+    OgreBites::ProgressBar* mHealthBar{nullptr};
+    OgreBites::Label* mScoreLabel{nullptr};
+    OgreBites::Label* mWeaponLabel{nullptr};
+
 };
 
 #endif // GAME_APP_HPP


### PR DESCRIPTION
## Summary
- fix stray header typo and include `<fstream>`
- allocate weapon & HUD pointers in GameApp
- drop unused projectile/target cleanup
- implement support helpers for pausing and restarting

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "OGRE")*

------
https://chatgpt.com/codex/tasks/task_e_683fca5a3bd883288957196c554c945f