### PR TITLE
Fix include and distinct projectile variables

### DIFF
--- a/src/GameApp.cpp
+++ b/src/GameApp.cpp
@@ -4,7 +4,7 @@
 #include <OgreEntity.h>
 #include <OgreMeshManager.h>
 #include <OgreRoot.h>
-#include <OgreVector3.h>8
+#include <OgreVector3.h>
 #include <OgreSceneNode.h>
 
 InputHandler::InputHandler(GameApp* app)
@@ -440,17 +440,17 @@ void GameApp::createBullet(const Ogre::Vector3& position, const Ogre::Quaternion
 
     Ogre::Vector3 forward = orient * Ogre::Vector3::NEGATIVE_UNIT_Z;
     body->setLinearVelocity(btVector3(forward.x, forward.y, forward.z) * 25.0f);
-    Projectile* proj = new Projectile();
-    proj->node = node;
-    proj->body = body;
-    proj->damage = 10;
+    Projectile* basicProj = new Projectile();
+    basicProj->node = node;
+    basicProj->body = body;
+    basicProj->damage = 10;
     mDynamicsWorld->addRigidBody(body);
 
-    BulletProjectile* proj = new BulletProjectile();
-    proj->node = node;
-    proj->body = body;
-    proj->life = 3.0f; // seconds
-    mBullets.push_back(proj);
+    BulletProjectile* bulletProj = new BulletProjectile();
+    bulletProj->node = node;
+    bulletProj->body = body;
+    bulletProj->life = 3.0f; // seconds
+    mBullets.push_back(bulletProj);
 }
 
 void GameApp::spawnEnemy(const Ogre::Vector3& position)


### PR DESCRIPTION
## Summary
- fix stray character in OgreVector3 include
- give unique names for Projectile and BulletProjectile variables

## Testing
- `cmake ..`
- `make -k` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_683fca5d45e48328a1b58ddd7041abed