### PR TITLE
Add level loader and HUD updates

### DIFF
--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -129,6 +129,14 @@ private:
     std::vector<BulletProjectile*> mBullets;
     std::vector<Enemy*> mEnemies;
 
+    GameState mGameState;
+
+    OgreBites::Label* mCrosshair{nullptr};
+    OgreBites::ProgressBar* mHealthBar{nullptr};
+    OgreBites::Label* mScoreLabel{nullptr};
+    OgreBites::Label* mWeaponLabel{nullptr};
+    Weapon* mWeapon{nullptr};
+
 };
 
 #endif // GAME_APP_HPP


### PR DESCRIPTION
## Summary
- add HUD member variables to `GameApp`
- parse `level.txt` in `loadLevel` and build static cubes
- keep HUD widgets updated each frame

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "OGRE")*

------
https://chatgpt.com/codex/tasks/task_e_683fca633b248328888721e03983f6ad