### PR TITLE
Add basic weapon system and bullet collision callbacks

### DIFF
--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -23,6 +23,8 @@ struct BulletProjectile
     Ogre::SceneNode* node;
     btRigidBody* body;
     float life;
+    int damage;
+    bool remove{false};
 };
 
 class Enemy
@@ -121,6 +123,9 @@ private:
     OgreBites::TrayManager* mTrayMgr;
     Ogre::OverlaySystem* mOverlaySystem;
     InputHandler* mInputHandler;
+
+    Weapon* mWeapon;
+    OgreBites::Label* mWeaponLabel;
 
     std::vector<BulletProjectile*> mBullets;
     std::vector<Enemy*> mEnemies;


### PR DESCRIPTION
## Summary
- flesh out BulletProjectile and store damage information
- track currently equipped weapon and display ammo using tray manager
- register rigid bodies with user pointers for collision handling
- detect projectile collisions using Bullet callbacks and apply damage

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "OGRE")*

------
https://chatgpt.com/codex/tasks/task_e_683fc86f5b248328af357dca691923e3