### PR TITLE
Fix weapon double delete and enable mouse input

### DIFF
--- a/src/GameApp.cpp
+++ b/src/GameApp.cpp
@@ -207,9 +207,6 @@ GameApp::~GameApp()
     delete mWeapon;
     mWeapon = nullptr;
 
-    delete mWeapon;
-    mWeapon = nullptr;
-
     for (int i = 0; i < mCollisionShapes.size(); ++i)
         delete mCollisionShapes[i];
     mCollisionShapes.clear();
@@ -351,7 +348,9 @@ bool GameApp::keyPressed(const OgreBites::KeyboardEvent& evt)
 bool GameApp::mousePressed(const OgreBites::MouseButtonEvent& evt)
 {
 
-    return true;
+    if (mInputHandler)
+        return mInputHandler->mousePressed(evt);
+    return false;
 }
 
 bool GameApp::frameRenderingQueued(const Ogre::FrameEvent& evt)


### PR DESCRIPTION
## Summary
- forward mouse clicks to InputHandler
- delete the weapon only once in `GameApp` destructor

## Testing
- `cmake ..` *(fails: Could not find OGRE)*

------
https://chatgpt.com/codex/tasks/task_e_6841332aca1483288c80e02468ee7f27