### PR TITLE
Improve input setup and weapon firing

### DIFF
--- a/src/GameApp.hpp
+++ b/src/GameApp.hpp
@@ -121,6 +121,7 @@ private:
     void togglePause();
     void updateHUD();
     void setGameOver(bool won);
+    void debugInputSystem();
 
     void spawnEnemy(const Ogre::Vector3& position);
 

--- a/src/Weapon.cpp
+++ b/src/Weapon.cpp
@@ -9,11 +9,27 @@ Weapon::Weapon(GameApp* app, const std::string& name, float rateOfFire, int ammo
 void Weapon::fire(const Ogre::Vector3& position, const Ogre::Quaternion& orient)
 {
     if (!canFire())
+    {
+        Ogre::LogManager::getSingleton().logMessage(
+            "Weapon::fire - Cannot fire (cooldown or no ammo)");
         return;
+    }
+
     --mAmmo;
     mCooldown = 1.0f / mRateOfFire;
+
+    Ogre::LogManager::getSingleton().logMessage(
+        "Weapon::fire - Firing! Ammo left: " + std::to_string(mAmmo));
+
     if (mApp)
+    {
         mApp->createBullet(position, orient);
+    }
+    else
+    {
+        Ogre::LogManager::getSingleton().logMessage(
+            "Weapon::fire - ERROR: mApp is null!");
+    }
 }
 
 void Weapon::update(float dt)


### PR DESCRIPTION
## Summary
- configure mouse input before creating the input handler
- register the input handler after setup is complete
- move mouse button handling from `InputHandler` to `GameApp`
- add debug logging helper for the input system
- add verbose messages to `Weapon::fire`

## Testing
- `cmake ..` *(fails: Could not find OGRE package)*
- `make` *(fails: No targets and no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6841e51169708328ad0d68c1e5afc025